### PR TITLE
Update card layout and styling for consistent alignment

### DIFF
--- a/src/components/IssueStatCard.tsx
+++ b/src/components/IssueStatCard.tsx
@@ -61,7 +61,7 @@ export function IssueStatCard({ title, target, actual, variant, className, leftL
         {/* Highlighted percentage */}
         <div className="mt-2 text-center">
           {variant === 'resolved' ? (
-            <span className="inline-flex items-center px-3 py-1 rounded-full bg-white text-red-600 text-base md:text-lg font-semibold">
+            <span className="inline-flex items-center px-3 py-1 rounded-full bg-[hsl(var(--danger))] text-white text-base md:text-lg font-semibold">
               {pct}%
             </span>
           ) : (

--- a/src/components/IssueStatCard.tsx
+++ b/src/components/IssueStatCard.tsx
@@ -35,7 +35,7 @@ export function IssueStatCard({ title, target, actual, variant, className, leftL
           {/* Left */}
           <div className="flex flex-col items-center">
             <div className="w-16 h-16 md:w-20 md:h-20 rounded-full bg-white flex items-center justify-center shadow-sm">
-              <span className={cn("font-semibold text-sm md:text-base", variant === 'resolved' ? 'text-white' : 'text-red-600')}>
+              <span className="text-red-600 font-semibold text-sm md:text-base">
                 {target.toLocaleString()}
               </span>
             </div>
@@ -50,7 +50,7 @@ export function IssueStatCard({ title, target, actual, variant, className, leftL
           {/* Right */}
           <div className="flex flex-col items-center">
             <div className="w-16 h-16 md:w-20 md:h-20 rounded-full bg-white flex items-center justify-center shadow-sm">
-              <span className={cn("font-semibold text-sm md:text-base", variant === 'resolved' ? 'text-white' : 'text-red-600')}>
+              <span className="text-red-600 font-semibold text-sm md:text-base">
                 {actual.toLocaleString()}
               </span>
             </div>

--- a/src/components/IssueStatCard.tsx
+++ b/src/components/IssueStatCard.tsx
@@ -35,7 +35,9 @@ export function IssueStatCard({ title, target, actual, variant, className, leftL
           {/* Left */}
           <div className="flex flex-col items-center">
             <div className="w-16 h-16 md:w-20 md:h-20 rounded-full bg-white flex items-center justify-center shadow-sm">
-              <span className="text-red-600 font-semibold text-sm md:text-base">{target.toLocaleString()}</span>
+              <span className={cn("font-semibold text-sm md:text-base", variant === 'resolved' ? 'text-white' : 'text-red-600')}>
+                {target.toLocaleString()}
+              </span>
             </div>
             <span className="mt-2 text-sm md:text-base opacity-90">{leftLabel}</span>
           </div>
@@ -48,13 +50,25 @@ export function IssueStatCard({ title, target, actual, variant, className, leftL
           {/* Right */}
           <div className="flex flex-col items-center">
             <div className="w-16 h-16 md:w-20 md:h-20 rounded-full bg-white flex items-center justify-center shadow-sm">
-              <span className="text-red-600 font-semibold text-sm md:text-base">{actual.toLocaleString()}</span>
+              <span className={cn("font-semibold text-sm md:text-base", variant === 'resolved' ? 'text-white' : 'text-red-600')}>
+                {actual.toLocaleString()}
+              </span>
             </div>
             <span className="mt-2 text-sm md:text-base opacity-90">{rightLabel}</span>
           </div>
         </div>
 
-        <div className="mt-2 text-center text-base md:text-lg font-semibold">{pct}%</div>
+        {/* Highlighted percentage */}
+        <div className="mt-2 text-center">
+          {variant === 'resolved' ? (
+            <span className="inline-flex items-center px-3 py-1 rounded-full bg-white text-red-600 text-base md:text-lg font-semibold">
+              {pct}%
+            </span>
+          ) : (
+            <div className="text-base md:text-lg font-semibold">{pct}%</div>
+          )}
+        </div>
+
         {subtitle && (
           <div className="mt-1 text-center text-xs md:text-sm opacity-80">{subtitle}</div>
         )}

--- a/src/components/IssueStatCard.tsx
+++ b/src/components/IssueStatCard.tsx
@@ -27,51 +27,55 @@ export function IssueStatCard({ title, target, actual, variant, className, leftL
   const rightLabel = rightLabelText ?? (variant === "raised" ? "Resolved" : "Actual");
 
   return (
-    <Card className={cn("rounded-2xl p-5 md:p-6", bgByVariant[variant], className)}>
-      <div className="flex flex-col items-center gap-4">
-        <h3 className={cn("text-xl md:text-2xl font-semibold text-center")}>{title}</h3>
+    <Card className={cn("rounded-2xl p-5 md:p-6 min-h-[260px]", bgByVariant[variant], className)}>
+      <div className="flex flex-col justify-between items-center h-full">
+        <div>
+          <h3 className={cn("text-xl md:text-2xl font-semibold text-center")}>{title}</h3>
 
-        <div className="w-full grid grid-cols-3 items-center gap-2 md:gap-4">
-          {/* Left */}
-          <div className="flex flex-col items-center">
-            <div className="w-16 h-16 md:w-20 md:h-20 rounded-full bg-white flex items-center justify-center shadow-sm">
-              <span className="text-red-600 font-semibold text-sm md:text-base">
-                {target.toLocaleString()}
-              </span>
+          <div className="w-full grid grid-cols-3 items-center gap-2 md:gap-4 mt-4">
+            {/* Left */}
+            <div className="flex flex-col items-center">
+              <div className="w-16 h-16 md:w-20 md:h-20 rounded-full bg-white flex items-center justify-center shadow-sm">
+                <span className="text-red-600 font-semibold text-sm md:text-base">
+                  {target.toLocaleString()}
+                </span>
+              </div>
+              <span className="mt-2 text-sm md:text-base opacity-90">{leftLabel}</span>
             </div>
-            <span className="mt-2 text-sm md:text-base opacity-90">{leftLabel}</span>
-          </div>
 
-          {/* Divider */}
-          <div className="flex items-center justify-center h-full">
-            <div className={cn("w-px h-14 md:h-16", variant === "resolved" ? "bg-white/70" : "bg-black/40")} />
-          </div>
-
-          {/* Right */}
-          <div className="flex flex-col items-center">
-            <div className="w-16 h-16 md:w-20 md:h-20 rounded-full bg-white flex items-center justify-center shadow-sm">
-              <span className="text-red-600 font-semibold text-sm md:text-base">
-                {actual.toLocaleString()}
-              </span>
+            {/* Divider */}
+            <div className="flex items-center justify-center h-full">
+              <div className={cn("w-px h-14 md:h-16", variant === "resolved" ? "bg-white/70" : "bg-black/40")} />
             </div>
-            <span className="mt-2 text-sm md:text-base opacity-90">{rightLabel}</span>
+
+            {/* Right */}
+            <div className="flex flex-col items-center">
+              <div className="w-16 h-16 md:w-20 md:h-20 rounded-full bg-white flex items-center justify-center shadow-sm">
+                <span className="text-red-600 font-semibold text-sm md:text-base">
+                  {actual.toLocaleString()}
+                </span>
+              </div>
+              <span className="mt-2 text-sm md:text-base opacity-90">{rightLabel}</span>
+            </div>
           </div>
         </div>
 
-        {/* Highlighted percentage */}
-        <div className="mt-2 text-center">
-          {variant === 'resolved' ? (
-            <span className="inline-flex items-center px-3 py-1 rounded-full bg-[hsl(var(--danger))] text-white text-base md:text-lg font-semibold">
-              {pct}%
-            </span>
-          ) : (
-            <div className="text-base md:text-lg font-semibold">{pct}%</div>
+        {/* Bottom: percentage and subtitle */}
+        <div className="w-full">
+          <div className="mt-2 text-center">
+            {variant === 'resolved' ? (
+              <span className="inline-flex items-center px-3 py-1 rounded-full bg-[hsl(var(--danger))] text-white text-base md:text-lg font-semibold">
+                {pct}%
+              </span>
+            ) : (
+              <div className="text-base md:text-lg font-semibold">{pct}%</div>
+            )}
+          </div>
+
+          {subtitle && (
+            <div className="mt-1 text-center text-xs md:text-sm opacity-80">{subtitle}</div>
           )}
         </div>
-
-        {subtitle && (
-          <div className="mt-1 text-center text-xs md:text-sm opacity-80">{subtitle}</div>
-        )}
       </div>
     </Card>
   );

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -74,8 +74,11 @@ export const MetricCard = ({
           <div className="mt-2 text-center">
             <span
               className={cn(
-                "inline-flex items-center px-3 py-1 rounded-full bg-white text-base md:text-lg font-semibold",
-                outlined ? outlinedTextClasses[variant] : `text-[hsl(var(--${variant}))]`
+                "inline-flex items-center px-3 py-1 rounded-full text-base md:text-lg font-semibold",
+                // Non-outlined cards: red pill with white text (match IssueStatCard red box)
+                !outlined ? "bg-[hsl(var(--danger))] text-white" : "bg-white",
+                // For outlined, set the text color to variant color (danger -> red)
+                outlined ? outlinedTextClasses[variant] : undefined
               )}
             >
               {subtitle}

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -55,6 +55,8 @@ export const MetricCard = ({
     primary: "text-[hsl(var(--primary))]",
   };
 
+  const outlinedColor = `hsl(var(--${variant}))`;
+
   return (
     <Card
       className={cn(
@@ -63,7 +65,7 @@ export const MetricCard = ({
         className
       )}
     >
-      <div className="flex items-start justify-between">
+      <div className="flex items-start justify-between" style={outlined ? { color: outlinedColor } : undefined}>
         <div className="flex-1">
           {headingOverride ? (
             <h3 className={cn("text-lg font-semibold text-foreground", headingClassName)}>

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -102,6 +102,20 @@ export const MetricCard = ({
           </div>
         )}
       </div>
+
+      {/* Centered percentage pill for percentage-like subtitles */}
+      {subtitle && subtitle.toString().trim().endsWith('%') && (
+        <div className="mt-4 flex justify-center">
+          <span
+            className={cn(
+              "inline-flex items-center px-3 py-1 rounded-full bg-white text-base md:text-lg font-semibold",
+              outlined ? outlinedTextClasses[variant] : undefined
+            )}
+          >
+            {subtitle}
+          </span>
+        </div>
+      )}
     </Card>
   );
 };

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -66,7 +66,7 @@ export const MetricCard = ({
 
       <div className="flex flex-col justify-between items-center h-full" style={outlined ? { color: outlinedColor } : undefined}>
         <div className="pt-4">
-          <h3 className={cn("text-xl font-semibold text-center", outlined ? outlinedTextClasses[variant] : "text-foreground")}>{title}</h3>
+          <h3 className={cn("text-xl font-semibold text-center", outlined ? outlinedTextClasses[variant] : "text-white")}>{title}</h3>
 
           <div className="flex items-center justify-center mt-3">
             <span className={cn("text-3xl md:text-4xl font-bold tracking-tight text-center", outlined ? outlinedTextClasses[variant] : undefined)}>{value}</span>

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -73,9 +73,9 @@ export const MetricCard = ({
             </h3>
           ) : (
             <>
-              <h3 className={cn("text-sm font-medium opacity-90 mb-3", outlined ? textVariantClasses[variant] : undefined)}>{title}</h3>
+              <h3 className={cn("text-sm font-medium opacity-90 mb-3", outlined ? outlinedTextClasses[variant] : undefined)}>{title}</h3>
               <div className="flex items-baseline gap-3">
-                <span className={cn("text-3xl font-bold tracking-tight", outlined ? textVariantClasses[variant] : undefined)}>{value}</span>
+                <span className={cn("text-3xl font-bold tracking-tight", outlined ? outlinedTextClasses[variant] : undefined)}>{value}</span>
                 {trend && (
                   <span
                     className={cn(
@@ -89,8 +89,9 @@ export const MetricCard = ({
                   </span>
                 )}
               </div>
-              {subtitle && (
-                <p className={cn("text-sm opacity-80 mt-2 leading-relaxed", outlined ? textVariantClasses[variant] : undefined)}>{subtitle}</p>
+              {/* If subtitle looks like a percentage, render as centered pill similar to IssueStatCard */}
+              {subtitle && subtitle.toString().trim().endsWith('%') ? null : (
+                <p className={cn("text-sm opacity-80 mt-2 leading-relaxed", outlined ? outlinedTextClasses[variant] : undefined)}>{subtitle}</p>
               )}
             </>
           )}

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -52,7 +52,7 @@ export const MetricCard = ({
   return (
     <Card
       className={cn(
-        "metric-card animate-card-enter interactive-hover relative",
+        "metric-card animate-card-enter interactive-hover relative min-h-[260px]",
         outlined ? "bg-white border border-border" : variantClasses[variant],
         className
       )}
@@ -64,15 +64,17 @@ export const MetricCard = ({
         </div>
       )}
 
-      <div className="flex flex-col items-center gap-4" style={outlined ? { color: outlinedColor } : undefined}>
-        <h3 className={cn("text-xl font-semibold text-center", outlined ? outlinedTextClasses[variant] : "text-foreground")}>{title}</h3>
+      <div className="flex flex-col justify-between items-center h-full" style={outlined ? { color: outlinedColor } : undefined}>
+        <div className="pt-4">
+          <h3 className={cn("text-xl font-semibold text-center", outlined ? outlinedTextClasses[variant] : "text-foreground")}>{title}</h3>
 
-        <div className="flex items-center justify-center">
-          <span className={cn("text-3xl md:text-4xl font-bold tracking-tight text-center", outlined ? outlinedTextClasses[variant] : undefined)}>{value}</span>
+          <div className="flex items-center justify-center mt-3">
+            <span className={cn("text-3xl md:text-4xl font-bold tracking-tight text-center", outlined ? outlinedTextClasses[variant] : undefined)}>{value}</span>
+          </div>
         </div>
 
         {subtitle && subtitle.toString().trim().endsWith('%') ? (
-          <div className="mt-2 text-center">
+          <div className="mb-6 text-center">
             <span
               className={cn(
                 "inline-flex items-center px-3 py-1 rounded-full text-base md:text-lg font-semibold",

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -1,4 +1,5 @@
 import { LucideIcon } from "lucide-react";
+import { LucideIcon } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -36,17 +36,8 @@ export const MetricCard = ({
     danger: "metric-card-danger",
     info: "metric-card-info",
     primary: "metric-card-primary",
-  };
+  } as const;
 
-  const textVariantClasses: Record<string, string> = {
-    success: "text-success-foreground",
-    warning: "text-warning-foreground",
-    danger: "text-danger-foreground",
-    info: "text-info-foreground",
-    primary: "text-primary-foreground",
-  };
-
-  // For outlined cards we need a contrasting text color (not the 'foreground' which may be white)
   const outlinedTextClasses: Record<string, string> = {
     success: "text-[hsl(var(--success))]",
     warning: "text-[hsl(var(--warning))]",
@@ -60,62 +51,40 @@ export const MetricCard = ({
   return (
     <Card
       className={cn(
-        "metric-card animate-card-enter interactive-hover",
-        outlined ? cn("bg-white border border-border", outlinedTextClasses[variant]) : variantClasses[variant],
+        "metric-card animate-card-enter interactive-hover relative",
+        outlined ? "bg-white border border-border" : variantClasses[variant],
         className
       )}
     >
-      <div className="flex items-start justify-between" style={outlined ? { color: outlinedColor } : undefined}>
-        <div className="flex-1">
-          {headingOverride ? (
-            <h3 className={cn("text-lg font-semibold text-foreground", headingClassName)}>
-              {headingOverride}
-            </h3>
-          ) : (
-            <>
-              <h3 className={cn("text-sm font-medium opacity-90 mb-3", outlined ? outlinedTextClasses[variant] : undefined)}>{title}</h3>
-              <div className="flex items-baseline gap-3">
-                <span className={cn("text-3xl font-bold tracking-tight", outlined ? outlinedTextClasses[variant] : undefined)}>{value}</span>
-                {trend && (
-                  <span
-                    className={cn(
-                      "text-sm font-medium px-2 py-1 rounded-full transition-all duration-300",
-                      trend.isPositive
-                        ? "text-success-light bg-success/10"
-                        : "text-danger-light bg-danger/10"
-                    )}
-                  >
-                    {trend.isPositive ? "↗" : "↘"} {Math.abs(trend.value)}%
-                  </span>
-                )}
-              </div>
-              {/* If subtitle looks like a percentage, render as centered pill similar to IssueStatCard */}
-              {subtitle && subtitle.toString().trim().endsWith('%') ? null : (
-                <p className={cn("text-sm opacity-80 mt-2 leading-relaxed", outlined ? outlinedTextClasses[variant] : undefined)}>{subtitle}</p>
-              )}
-            </>
-          )}
-        </div>
-        {Icon && (
-          <div className="p-3 rounded-xl bg-black/10 animate-float">
-            <Icon className="h-7 w-7" />
-          </div>
-        )}
-      </div>
-
-      {/* Centered percentage pill for percentage-like subtitles */}
-      {subtitle && subtitle.toString().trim().endsWith('%') && (
-        <div className="mt-4 flex justify-center">
-          <span
-            className={cn(
-              "inline-flex items-center px-3 py-1 rounded-full bg-white text-base md:text-lg font-semibold",
-              outlined ? outlinedTextClasses[variant] : undefined
-            )}
-          >
-            {subtitle}
-          </span>
+      {/* Top-right icon */}
+      {Icon && (
+        <div className="absolute top-4 right-4 p-3 rounded-xl bg-black/10 animate-float">
+          <Icon className="h-7 w-7" />
         </div>
       )}
+
+      <div className="flex flex-col items-center gap-4" style={outlined ? { color: outlinedColor } : undefined}>
+        <h3 className={cn("text-xl font-semibold text-center", outlined ? outlinedTextClasses[variant] : "text-foreground")}>{title}</h3>
+
+        <div className="flex items-center justify-center">
+          <span className={cn("text-3xl md:text-4xl font-bold tracking-tight text-center", outlined ? outlinedTextClasses[variant] : undefined)}>{value}</span>
+        </div>
+
+        {subtitle && subtitle.toString().trim().endsWith('%') ? (
+          <div className="mt-2 text-center">
+            <span
+              className={cn(
+                "inline-flex items-center px-3 py-1 rounded-full bg-white text-base md:text-lg font-semibold",
+                outlined ? outlinedTextClasses[variant] : `text-[hsl(var(--${variant}))]`
+              )}
+            >
+              {subtitle}
+            </span>
+          </div>
+        ) : subtitle ? (
+          <p className={cn("text-sm opacity-80 mt-2 leading-relaxed", outlined ? outlinedTextClasses[variant] : undefined)}>{subtitle}</p>
+        ) : null}
+      </div>
     </Card>
   );
 };

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -46,11 +46,20 @@ export const MetricCard = ({
     primary: "text-primary-foreground",
   };
 
+  // For outlined cards we need a contrasting text color (not the 'foreground' which may be white)
+  const outlinedTextClasses: Record<string, string> = {
+    success: "text-[hsl(var(--success))]",
+    warning: "text-[hsl(var(--warning))]",
+    danger: "text-[hsl(var(--danger))]",
+    info: "text-[hsl(var(--info))]",
+    primary: "text-[hsl(var(--primary))]",
+  };
+
   return (
     <Card
       className={cn(
         "metric-card animate-card-enter interactive-hover",
-        outlined ? cn("bg-white border border-border", textVariantClasses[variant]) : variantClasses[variant],
+        outlined ? cn("bg-white border border-border", outlinedTextClasses[variant]) : variantClasses[variant],
         className
       )}
     >

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -69,7 +69,7 @@ export const MetricCard = ({
           <h3 className={cn("text-xl font-semibold text-center", outlined ? outlinedTextClasses[variant] : "text-white")}>{title}</h3>
 
           <div className="flex items-center justify-center mt-3">
-            <span className={cn("text-3xl md:text-4xl font-bold tracking-tight text-center", outlined ? outlinedTextClasses[variant] : undefined)}>{value}</span>
+            <span className={cn("text-3xl md:text-4xl font-bold tracking-tight text-center", outlined ? outlinedTextClasses[variant] : "text-white")}>{value}</span>
           </div>
         </div>
 

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -15,6 +15,7 @@ interface MetricCardProps {
   className?: string;
   headingOverride?: string;
   headingClassName?: string;
+  outlined?: boolean;
 }
 
 export const MetricCard = ({

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -62,9 +62,9 @@ export const MetricCard = ({
             </h3>
           ) : (
             <>
-              <h3 className="text-sm font-medium opacity-90 mb-3">{title}</h3>
+              <h3 className={cn("text-sm font-medium opacity-90 mb-3", outlined ? textVariantClasses[variant] : undefined)}>{title}</h3>
               <div className="flex items-baseline gap-3">
-                <span className="text-3xl font-bold tracking-tight">{value}</span>
+                <span className={cn("text-3xl font-bold tracking-tight", outlined ? textVariantClasses[variant] : undefined)}>{value}</span>
                 {trend && (
                   <span
                     className={cn(
@@ -79,7 +79,7 @@ export const MetricCard = ({
                 )}
               </div>
               {subtitle && (
-                <p className="text-sm opacity-80 mt-2 leading-relaxed">{subtitle}</p>
+                <p className={cn("text-sm opacity-80 mt-2 leading-relaxed", outlined ? textVariantClasses[variant] : undefined)}>{subtitle}</p>
               )}
             </>
           )}

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -27,7 +27,8 @@ export const MetricCard = ({
   className,
   headingOverride,
   headingClassName,
-}: MetricCardProps) => {
+  outlined,
+}: MetricCardProps & { outlined?: boolean }) => {
   const variantClasses = {
     success: "metric-card-success",
     warning: "metric-card-warning",
@@ -36,11 +37,19 @@ export const MetricCard = ({
     primary: "metric-card-primary",
   };
 
+  const textVariantClasses: Record<string, string> = {
+    success: "text-success-foreground",
+    warning: "text-warning-foreground",
+    danger: "text-danger-foreground",
+    info: "text-info-foreground",
+    primary: "text-primary-foreground",
+  };
+
   return (
-    <Card 
+    <Card
       className={cn(
         "metric-card animate-card-enter interactive-hover",
-        variantClasses[variant],
+        outlined ? cn("bg-white border border-border", textVariantClasses[variant]) : variantClasses[variant],
         className
       )}
     >

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -69,7 +69,6 @@ const Home = () => {
           value="Baharudgarh"
           subtitle="29%"
           variant="danger"
-          outlined
         />
       </div>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -48,7 +48,7 @@ const Home = () => {
   return (
     <div className="space-y-6">
       {/* Summary Cards - DSP style */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         <IssueStatCard
           title="Actual Issues"
           target={totals.actualRaised}
@@ -58,9 +58,6 @@ const Home = () => {
           rightLabelText="Resolved"
           subtitle="(Average Resolution Rate)"
         />
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <MetricCard
           title="City with Highest Resolution Rate"
           value="Noida"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -62,14 +62,12 @@ const Home = () => {
           title="City with Highest Resolution Rate"
           value="Noida"
           subtitle="93%"
-          icon={Trophy}
           variant="success"
         />
         <MetricCard
           title="City with Lowest Resolution Rate"
           value="Baharudgarh"
           subtitle="29%"
-          icon={ArrowDownCircle}
           variant="danger"
           outlined
         />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -71,6 +71,7 @@ const Home = () => {
           subtitle="29%"
           icon={ArrowDownCircle}
           variant="danger"
+          outlined
         />
       </div>
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses visual consistency issues across the three dashboard cards. Users requested:
- Proper alignment of percentage values across all cards
- Consistent styling and layout between cards
- Red highlighting for the lowest resolution rate card with white text
- Removal of icons from metric cards
- White text color for city resolution rate titles

## Code changes

### IssueStatCard.tsx
- Added `min-h-[260px]` for consistent card height
- Restructured layout with `justify-between` for proper spacing
- Added red pill styling for resolved variant percentage display
- Improved responsive design with better flex layout

### MetricCard.tsx
- Added `outlined` prop for variant styling options
- Implemented consistent card height (`min-h-[260px]`)
- Added red pill styling for percentage subtitles to match other cards
- Removed icon positioning and added color variants for outlined cards
- Centered content layout for better alignment

### Home.tsx
- Changed grid layout from 2 columns to 3 columns for better card distribution
- Removed icon props from MetricCard components
- Consolidated all three cards into a single grid row

These changes ensure all three cards have consistent visual alignment, proper text contrast, and unified styling across the dashboard.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1702ca33e34c4a5e913fcbfef3cc90ed/vortex-haven)

👀 [Preview Link](https://1702ca33e34c4a5e913fcbfef3cc90ed-vortex-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1702ca33e34c4a5e913fcbfef3cc90ed</projectId>-->
<!--<branchName>vortex-haven</branchName>-->